### PR TITLE
Update dependencies and centralize plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,26 +47,29 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Dependencies -->
-    <jakarta-xml-bind-api.version>4.0.2</jakarta-xml-bind-api.version>
-    <jaxb.version>4.0.5</jaxb.version>
-    <jaxb-xjc.version>4.0.5</jaxb-xjc.version>
-    <milo.version>1.0.6</milo.version>
+    <jakarta-xml-bind-api.version>4.0.4</jakarta-xml-bind-api.version>
+    <jaxb.version>4.0.6</jaxb.version>
+    <jaxb-xjc.version>4.0.6</jaxb-xjc.version>
+    <milo.version>1.0.8</milo.version>
     <slf4j.version>2.0.17</slf4j.version>
 
     <!-- Test Dependencies -->
-    <junit.version>5.12.1</junit.version>
+    <junit.version>6.0.1</junit.version>
 
     <!-- Plugin Dependencies -->
-    <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
-    <jaxb2-maven-plugin.version>3.2.0</jaxb2-maven-plugin.version>
-    <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
+    <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
+    <jaxb2-maven-plugin.version>4.0.0</jaxb2-maven-plugin.version>
+    <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.9.0</maven-dependency-plugin.version>
-    <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
-    <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
-    <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
-    <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
-    <spotless-maven-plugin.version>3.0.0</spotless-maven-plugin.version>
-    <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
+    <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
+    <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
+    <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
+    <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
+    <maven-release-plugin.version>3.2.0</maven-release-plugin.version>
+    <maven-resources-plugin.version>3.4.0</maven-resources-plugin.version>
+    <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
+    <spotless-maven-plugin.version>3.1.0</spotless-maven-plugin.version>
+    <versions-maven-plugin.version>2.20.1</versions-maven-plugin.version>
   </properties>
 
   <profiles>
@@ -95,7 +98,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.3.1</version>
+            <version>${maven-source-plugin.version}</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -108,7 +111,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
-            <version>3.4.2</version>
+            <version>${maven-jar-plugin.version}</version>
             <configuration>
               <archive>
                 <manifest>
@@ -153,7 +156,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-release-plugin</artifactId>
-            <version>3.1.1</version>
+            <version>${maven-release-plugin.version}</version>
             <configuration>
               <tagNameFormat>v@{project.version}</tagNameFormat>
             </configuration>
@@ -218,7 +221,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.4.2</version>
+        <version>${maven-jar-plugin.version}</version>
         <configuration>
           <archive>
             <manifest>
@@ -230,7 +233,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>${maven-resources-plugin.version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

Update dependencies to latest versions:
- jakarta-xml-bind-api 4.0.2 → 4.0.4
- jaxb/jaxb-xjc 4.0.5 → 4.0.6
- milo 1.0.6 → 1.0.8
- junit 5.12.1 → 6.0.1

Update Maven plugins:
- central-publishing-maven-plugin 0.7.0 → 0.9.0
- jaxb2-maven-plugin 3.2.0 → 4.0.0
- maven-compiler-plugin 3.14.0 → 3.14.1
- maven-enforcer-plugin 3.5.0 → 3.6.2
- maven-gpg-plugin 3.2.7 → 3.2.8
- maven-javadoc-plugin 3.11.2 → 3.12.0
- maven-release-plugin 3.1.1 → 3.2.0
- spotless-maven-plugin 3.0.0 → 3.1.0
- versions-maven-plugin 2.18.0 → 2.20.1

Add version properties for maven-jar-plugin, maven-resources-plugin, and maven-source-plugin to replace hardcoded versions.