### PR TITLE
Reindex StructureDefinition.baseDataType in NodeSetNodeLoader

### DIFF
--- a/uanodeset-namespace/pom.xml
+++ b/uanodeset-namespace/pom.xml
@@ -30,6 +30,12 @@
       <artifactId>milo-encoding-xml</artifactId>
       <version>${milo.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/uanodeset-namespace/src/main/java/com/digitalpetri/opcua/uanodeset/namespace/NodeSetNodeLoader.java
+++ b/uanodeset-namespace/src/main/java/com/digitalpetri/opcua/uanodeset/namespace/NodeSetNodeLoader.java
@@ -774,7 +774,8 @@ public class NodeSetNodeLoader {
     return new AccessRestrictionType(ushort(value));
   }
 
-  private org.eclipse.milo.opcua.stack.core.types.structured.@Nullable DataTypeDefinition
+  // package-private visible for testing
+  org.eclipse.milo.opcua.stack.core.types.structured.@Nullable DataTypeDefinition
       newDataTypeDefinition(UADataType dataType, DataTypeInfoTree dataTypeTree) {
 
     DataTypeDefinition definition = dataType.getDefinition();
@@ -796,7 +797,7 @@ public class NodeSetNodeLoader {
     } else if (dataTypeTree.isStructure(dataType.getNodeId())) {
       NodeId baseDataType = NodeId.NULL_VALUE;
       if (typeInfo != null && typeInfo.getParent() != null) {
-        baseDataType = NodeId.parse(typeInfo.getParent().getTypeNode().getNodeId());
+        baseDataType = reindexNodeId(typeInfo.getParent().getTypeNode().getNodeId());
       }
 
       if (dataTypeTree.isOptionSet(dataType.getNodeId())) {

--- a/uanodeset-namespace/src/test/java/com/digitalpetri/opcua/uanodeset/namespace/NodeSetNodeLoaderDataTypeDefinitionTest.java
+++ b/uanodeset-namespace/src/test/java/com/digitalpetri/opcua/uanodeset/namespace/NodeSetNodeLoaderDataTypeDefinitionTest.java
@@ -1,0 +1,146 @@
+package com.digitalpetri.opcua.uanodeset.namespace;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.digitalpetri.opcua.uanodeset.DataTypeInfoTree;
+import com.digitalpetri.opcua.uanodeset.NodeSet;
+import java.io.InputStream;
+import java.util.Objects;
+import org.eclipse.milo.opcua.sdk.server.NodeManager;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig;
+import org.eclipse.milo.opcua.sdk.server.UaNodeManager;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.eclipse.milo.opcua.stack.core.types.structured.DataTypeDefinition;
+import org.eclipse.milo.opcua.stack.core.types.structured.StructureDefinition;
+import org.eclipse.milo.opcua.stack.transport.server.OpcServerTransportFactory;
+import org.junit.jupiter.api.Test;
+import org.opcfoundation.ua.UADataType;
+
+class NodeSetNodeLoaderDataTypeDefinitionTest {
+
+  private static final String TEST_NAMESPACE_URI = "urn:uanodeset:test:basedatatype-reindex";
+
+  /**
+   * Regression test: the baseDataType of a StructureDefinition must be reindexed against the server
+   * namespace table, like every other NodeId in the definition.
+   *
+   * <p>The fixture defines ConcreteTestType (ns=1;i=3006) as a subtype of AbstractTestType
+   * (ns=1;i=3003), with namespace index 1 local to the NodeSet file. The server namespace table is
+   * arranged so that the test namespace gets an index different from 1 — like the DataTypeTest
+   * namespace on the public Milo demo server, where this bug was originally observed (advertised
+   * baseDataType ns=1;i=3003 did not exist in the server address space; see
+   * node-opcua/node-opcua#1520).
+   */
+  @Test
+  void baseDataTypeIsReindexedAgainstServerNamespaceTable() throws Exception {
+    InputStream inputStream =
+        Objects.requireNonNull(getClass().getResourceAsStream("/BaseDataTypeReindex.NodeSet2.xml"));
+
+    NodeSet nodeSet = NodeSet.load(inputStream);
+
+    OpcUaServer server = newBareServer();
+    // add filler namespaces so the test namespace lands on an index different from its
+    // file-local index 1, like the DataTypeTest namespace on the public Milo demo server
+    server.getNamespaceTable().add("urn:filler:1");
+    server.getNamespaceTable().add("urn:filler:2");
+    UShort serverIndex = server.getNamespaceTable().add(TEST_NAMESPACE_URI);
+    assertNotEquals(ushort(1), serverIndex);
+
+    var nodeManager = new UaNodeManager();
+    var context =
+        new UaNodeContext() {
+          @Override
+          public OpcUaServer getServer() {
+            return server;
+          }
+
+          @Override
+          public NodeManager<UaNode> getNodeManager() {
+            return nodeManager;
+          }
+        };
+
+    var loader =
+        new NodeSetNodeLoader(
+            nodeSet, context, server.getStaticEncodingContext(), TEST_NAMESPACE_URI::equals);
+
+    DataTypeInfoTree dataTypeTree = DataTypeInfoTree.create(nodeSet);
+
+    UADataType concreteTestType = getDataType(nodeSet, "ns=1;i=3006");
+    DataTypeDefinition definition = loader.newDataTypeDefinition(concreteTestType, dataTypeTree);
+
+    StructureDefinition structureDefinition =
+        assertInstanceOf(StructureDefinition.class, definition);
+
+    // the parent AbstractTestType is ns=1;i=3003 in the NodeSet file and must be
+    // reindexed to the index of the test namespace in the server namespace table
+    assertEquals(new NodeId(serverIndex, 3003), structureDefinition.getBaseDataType());
+  }
+
+  /** A baseDataType from namespace 0 must remain untouched. */
+  @Test
+  void namespaceZeroBaseDataTypeIsUnchanged() throws Exception {
+    InputStream inputStream =
+        Objects.requireNonNull(getClass().getResourceAsStream("/BaseDataTypeReindex.NodeSet2.xml"));
+
+    NodeSet nodeSet = NodeSet.load(inputStream);
+
+    OpcUaServer server = newBareServer();
+    server.getNamespaceTable().add(TEST_NAMESPACE_URI);
+
+    var nodeManager = new UaNodeManager();
+    var context =
+        new UaNodeContext() {
+          @Override
+          public OpcUaServer getServer() {
+            return server;
+          }
+
+          @Override
+          public NodeManager<UaNode> getNodeManager() {
+            return nodeManager;
+          }
+        };
+
+    var loader =
+        new NodeSetNodeLoader(
+            nodeSet, context, server.getStaticEncodingContext(), TEST_NAMESPACE_URI::equals);
+
+    DataTypeInfoTree dataTypeTree = DataTypeInfoTree.create(nodeSet);
+
+    UADataType abstractTestType = getDataType(nodeSet, "ns=1;i=3003");
+    DataTypeDefinition definition = loader.newDataTypeDefinition(abstractTestType, dataTypeTree);
+
+    StructureDefinition structureDefinition =
+        assertInstanceOf(StructureDefinition.class, definition);
+
+    // the parent of AbstractTestType is i=22 (Structure), namespace 0: no reindexing
+    assertEquals(new NodeId(0, 22), structureDefinition.getBaseDataType());
+  }
+
+  private static UADataType getDataType(NodeSet nodeSet, String nodeId) {
+    UADataType dataType =
+        nodeSet.getNodeSet().getUAObjectOrUAVariableOrUAMethod().stream()
+            .filter(UADataType.class::isInstance)
+            .map(UADataType.class::cast)
+            .filter(node -> nodeId.equals(node.getNodeId()))
+            .findFirst()
+            .orElse(null);
+    assertNotNull(dataType, "fixture DataType not found: " + nodeId);
+    return dataType;
+  }
+
+  private static OpcUaServer newBareServer() {
+    OpcUaServerConfig config = OpcUaServerConfig.builder().build();
+    OpcServerTransportFactory transportFactory = profile -> null;
+    return new OpcUaServer(config, transportFactory);
+  }
+}

--- a/uanodeset-namespace/src/test/resources/BaseDataTypeReindex.NodeSet2.xml
+++ b/uanodeset-namespace/src/test/resources/BaseDataTypeReindex.NodeSet2.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd">
+  <NamespaceUris>
+    <Uri>urn:uanodeset:test:basedatatype-reindex</Uri>
+  </NamespaceUris>
+  <Models>
+    <Model ModelUri="urn:uanodeset:test:basedatatype-reindex" Version="1.0.0"
+      PublicationDate="2026-01-01T00:00:00Z">
+      <RequiredModel ModelUri="http://opcfoundation.org/UA/" Version="1.05.04"
+        PublicationDate="2024-12-01T00:00:00Z"/>
+    </Model>
+  </Models>
+  <Aliases>
+    <Alias Alias="HasSubtype">i=45</Alias>
+    <Alias Alias="Boolean">i=1</Alias>
+    <Alias Alias="Int16">i=4</Alias>
+  </Aliases>
+  <UADataType NodeId="ns=1;i=3003" BrowseName="1:AbstractTestType" IsAbstract="true">
+    <DisplayName>AbstractTestType</DisplayName>
+    <References>
+      <Reference IsForward="false" ReferenceType="HasSubtype">i=22</Reference>
+    </References>
+    <Definition Name="1:AbstractTestType">
+      <Field Name="Int16Field" DataType="Int16"/>
+    </Definition>
+  </UADataType>
+  <UADataType NodeId="ns=1;i=3006" BrowseName="1:ConcreteTestType">
+    <DisplayName>ConcreteTestType</DisplayName>
+    <References>
+      <Reference IsForward="false" ReferenceType="HasSubtype">ns=1;i=3003</Reference>
+    </References>
+    <Definition Name="1:ConcreteTestType">
+      <Field Name="BooleanField" DataType="Boolean"/>
+    </Definition>
+  </UADataType>
+</UANodeSet>


### PR DESCRIPTION
Fixes #14.

`newDataTypeDefinition()` now passes the parent's NodeId through `reindexNodeId()`, like the other NodeIds that end up in the `StructureDefinition`.

Includes a regression test: it loads a minimal NodeSet in which a custom structure subtypes another custom structure, and asserts that the published `baseDataType` is reindexed against the server namespace table (without the fix it comes out with the file-local `ns=1`). To make the method reachable from the test, `newDataTypeDefinition` is relaxed to package-private — happy to change that if you'd prefer a different approach.

Also verified end-to-end by building the demo server against this branch: the advertised `baseDataType` values then match the `HasSubtype` references, and node-opcua decodes all the DataTypeTest types it previously couldn't.