### PR TITLE
Fix QualifiedName reindexing for reordering merges

### DIFF
--- a/uanodeset-core/src/main/java/com/digitalpetri/opcua/uanodeset/parser/IndexUtil.java
+++ b/uanodeset-core/src/main/java/com/digitalpetri/opcua/uanodeset/parser/IndexUtil.java
@@ -110,16 +110,16 @@ public final class IndexUtil {
       if (originalIndex == 0) {
         return qualifiedName;
       } else {
-        String originalUri = originalTable.getUri().get(originalIndex - 1);
+        String originalUri = originalTable.getUri().get(originalIndex);
         int mergedIndex = mergedTable.getUri().indexOf(originalUri);
 
         if (mergedIndex == -1) {
           throw new IllegalArgumentException("URI not found in mergedTable: " + originalUri);
-        } else if (mergedIndex + 1 == originalIndex) {
+        } else if (mergedIndex == originalIndex) {
           // Don't call redundant String.format if the indices turn out to be the same.
           return qualifiedName;
         } else {
-          return String.format("%d:%s", mergedIndex + 1, m.group(2));
+          return String.format("%d:%s", mergedIndex, m.group(2));
         }
       }
     } else {

--- a/uanodeset-core/src/test/java/com/digitalpetri/opcua/uanodeset/parser/IndexUtilTest.java
+++ b/uanodeset-core/src/test/java/com/digitalpetri/opcua/uanodeset/parser/IndexUtilTest.java
@@ -64,10 +64,12 @@ class IndexUtilTest {
     var qualifiedName = "1:Foo";
 
     var merged = new UriTable();
+    merged.getUri().add(Namespaces.OPC_UA);
     merged.getUri().add("uri1");
     merged.getUri().add("uri2");
 
     var original = new UriTable();
+    original.getUri().add(Namespaces.OPC_UA);
     original.getUri().add("uri2");
 
     String reindexed = IndexUtil.reindexQualifiedName(qualifiedName, merged, original);
@@ -76,13 +78,53 @@ class IndexUtilTest {
   }
 
   @Test
+  public void testReindexQualifiedNameNoOp() {
+    var qualifiedName = "1:Foo";
+
+    var merged = new UriTable();
+    merged.getUri().add(Namespaces.OPC_UA);
+    merged.getUri().add("uri1");
+
+    var original = new UriTable();
+    original.getUri().add(Namespaces.OPC_UA);
+    original.getUri().add("uri1");
+
+    String reindexed = IndexUtil.reindexQualifiedName(qualifiedName, merged, original);
+
+    assertEquals("1:Foo", reindexed);
+  }
+
+  @Test
+  public void testReindexQualifiedNameWithReordering() {
+    // A namespace that moves position during a merge (as O-PAS does, from index 1 to a higher
+    // index) must have its BrowseName namespace index remapped the same way as a NodeId.
+    var qualifiedName = "1:Foo";
+
+    var merged = new UriTable();
+    merged.getUri().add(Namespaces.OPC_UA);
+    merged.getUri().add("uriA");
+    merged.getUri().add("uriB");
+    merged.getUri().add("uriTarget");
+
+    var original = new UriTable();
+    original.getUri().add(Namespaces.OPC_UA);
+    original.getUri().add("uriTarget");
+
+    String reindexed = IndexUtil.reindexQualifiedName(qualifiedName, merged, original);
+
+    assertEquals("3:Foo", reindexed);
+  }
+
+  @Test
   public void testReindexQualifiedNameThrowsOnMissingUri() {
     var qualifiedName = "1:Foo";
 
     var merged = new UriTable();
+    merged.getUri().add(Namespaces.OPC_UA);
     merged.getUri().add("uri1");
 
     var original = new UriTable();
+    original.getUri().add(Namespaces.OPC_UA);
     original.getUri().add("uri2");
 
     assertThrows(


### PR DESCRIPTION
## Summary

`IndexUtil.reindexQualifiedName` indexed the namespace table with an off-by-one (`originalIndex - 1` on lookup, `mergedIndex + 1` on output) relative to `reindexNodeId`, which indexes the UA-prepended table directly.

The two off-by-ones cancel **as long as a namespace keeps its position through a merge**, so every spec merged so far — a single companion model merged onto the base (BACnet, GDS, DI, Safety, …) — was unaffected, and the bug stayed latent.

They stop cancelling when a merge **reorders** namespaces — e.g. a model that declares its own namespace ahead of its dependencies (O-PAS declares `[O-PAS, PADIM, DI]` but merges into `[…, DI, IRDI, PADIM, O-PAS]`). In that case BrowseNames resolve to the wrong namespace or to an out-of-range index.

## Fix

- Index the merged namespace table directly, matching `reindexNodeId` (the canonical reindexing used for NodeIds).
- Update `IndexUtilTest` to pass UA-prepended tables (as `reindexUANode` actually does), and add a case covering the reordering scenario.

## Verification

Regenerated **GDS (70 files)**, the full **Milo base set (1,840 files)**, and **BACnet (162 files)** with the old vs. new `IndexUtil` and diffed: **byte-for-byte identical** in all three. The only behavioral change is that namespace-reordering merges now reindex BrowseNames correctly instead of corrupting them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)