### PR TITLE
Release version 0.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.digitalpetri.opcua</groupId>
   <artifactId>uanodeset</artifactId>
-  <version>0.5.0</version>
+  <version>0.5.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>UANodeSet</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.digitalpetri.opcua</groupId>
   <artifactId>uanodeset</artifactId>
-  <version>0.5.0-SNAPSHOT</version>
+  <version>0.5.0</version>
   <packaging>pom</packaging>
 
   <name>UANodeSet</name>

--- a/uanodeset-core/pom.xml
+++ b/uanodeset-core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.digitalpetri.opcua</groupId>
     <artifactId>uanodeset</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
+    <version>0.5.0</version>
   </parent>
 
   <name>UANodeSet :: Core</name>

--- a/uanodeset-core/pom.xml
+++ b/uanodeset-core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.digitalpetri.opcua</groupId>
     <artifactId>uanodeset</artifactId>
-    <version>0.5.0</version>
+    <version>0.5.1-SNAPSHOT</version>
   </parent>
 
   <name>UANodeSet :: Core</name>

--- a/uanodeset-namespace/pom.xml
+++ b/uanodeset-namespace/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.digitalpetri.opcua</groupId>
     <artifactId>uanodeset</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
+    <version>0.5.0</version>
   </parent>
 
   <name>UANodeSet :: Namespace</name>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.digitalpetri.opcua</groupId>
       <artifactId>uanodeset-core</artifactId>
-      <version>0.5.0-SNAPSHOT</version>
+      <version>0.5.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.milo</groupId>

--- a/uanodeset-namespace/pom.xml
+++ b/uanodeset-namespace/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.digitalpetri.opcua</groupId>
     <artifactId>uanodeset</artifactId>
-    <version>0.5.0</version>
+    <version>0.5.1-SNAPSHOT</version>
   </parent>
 
   <name>UANodeSet :: Namespace</name>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.digitalpetri.opcua</groupId>
       <artifactId>uanodeset-core</artifactId>
-      <version>0.5.0</version>
+      <version>0.5.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.milo</groupId>


### PR DESCRIPTION
## Summary

- release version 0.5.0 from the verified release candidate
- advance the reactor to 0.5.1-SNAPSHOT for continued development

## Verification

- mise exec -- mvn -q clean verify at 0.5.0
- Maven Central deployment succeeded: https://github.com/digitalpetri/uanodeset/actions/runs/29650653620
- mise exec -- mvn -q clean verify at 0.5.1-SNAPSHOT

Release: https://github.com/digitalpetri/uanodeset/releases/tag/v0.5.0