### PR TITLE
Update build and CI dependencies

### DIFF
--- a/.github/workflows/maven-deploy-snapshot.yml
+++ b/.github/workflows/maven-deploy-snapshot.yml
@@ -8,10 +8,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -12,10 +12,10 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Java for publishing to Maven Central
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,10 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/pom.xml
+++ b/pom.xml
@@ -54,10 +54,10 @@
     <slf4j.version>2.0.18</slf4j.version>
 
     <!-- Test Dependencies -->
-    <junit.version>6.1.0</junit.version>
+    <junit.version>6.1.2</junit.version>
 
     <!-- Plugin Dependencies -->
-    <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
+    <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     <jaxb2-maven-plugin.version>4.1.0</jaxb2-maven-plugin.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
@@ -69,7 +69,7 @@
     <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
-    <spotless-maven-plugin.version>3.6.0</spotless-maven-plugin.version>
+    <spotless-maven-plugin.version>3.8.0</spotless-maven-plugin.version>
     <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
   </properties>
 


### PR DESCRIPTION
## Summary

- update `actions/checkout` from v4 to v7 across all workflows
- update `actions/setup-java` from v4 to v5 across all workflows
- update JUnit Jupiter from 6.1.0 to 6.1.2
- update the Spotless Maven Plugin from 3.6.0 to 3.8.0
- update the Central Publishing Maven Plugin from 0.10.0 to 0.11.0

## Why

Keep the repository’s CI actions, test framework, formatting plugin, and publishing tooling on their latest stable releases.

## Impact

This changes build and CI configuration only. No application source code or behavior is intentionally changed.

## Validation

- `mise exec -- mvn -q dependency:resolve`
- `mise exec -- mvn -q clean verify`
- 47 tests passed with 0 failures, errors, or skips
