### PR TITLE
Prevent duplicate NodeSet references

### DIFF
--- a/uanodeset-namespace/src/main/java/com/digitalpetri/opcua/uanodeset/namespace/NodeSetNodeLoader.java
+++ b/uanodeset-namespace/src/main/java/com/digitalpetri/opcua/uanodeset/namespace/NodeSetNodeLoader.java
@@ -18,7 +18,9 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.stream.Stream;
@@ -126,6 +128,8 @@ public class NodeSetNodeLoader {
   }
 
   public void loadNodes() {
+    Set<ReferenceKey> loadedReferences = new HashSet<>();
+
     // Add references for all nodes.
     for (UANode node : nodeSet.getNodeSet().getUAObjectOrUAVariableOrUAMethod()) {
       String nodeId = resolveAlias(node.getNodeId());
@@ -136,7 +140,9 @@ public class NodeSetNodeLoader {
         for (Reference reference : node.getReferences().getReference()) {
           org.eclipse.milo.opcua.sdk.core.Reference ref = reindexReference(node, reference);
 
-          context.getNodeManager().addReferences(ref, context.getServer().getNamespaceTable());
+          if (loadedReferences.add(toReferenceKey(ref))) {
+            context.getNodeManager().addReferences(ref, context.getServer().getNamespaceTable());
+          }
         }
       }
     }
@@ -752,6 +758,26 @@ public class NodeSetNodeLoader {
         targetNodeId.expanded(context.getServer().getNamespaceTable()),
         reference.isIsForward());
   }
+
+  private ReferenceKey toReferenceKey(org.eclipse.milo.opcua.sdk.core.Reference reference) {
+    NodeId targetNodeId =
+        reference
+            .getTargetNodeId()
+            .toNodeId(context.getServer().getNamespaceTable())
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "NodeSet reference target is not local: " + reference.getTargetNodeId()));
+
+    return reference.isForward()
+        ? new ReferenceKey(
+            reference.getSourceNodeId(), reference.getReferenceTypeId(), targetNodeId)
+        : new ReferenceKey(
+            targetNodeId, reference.getReferenceTypeId(), reference.getSourceNodeId());
+  }
+
+  private record ReferenceKey(
+      NodeId forwardSourceNodeId, NodeId referenceTypeId, NodeId forwardTargetNodeId) {}
 
   private String resolveAlias(String nodeIdString) {
     // TODO put these into a map to improve lookup performance

--- a/uanodeset-namespace/src/test/java/com/digitalpetri/opcua/uanodeset/namespace/NodeSetNodeLoaderReferenceTest.java
+++ b/uanodeset-namespace/src/test/java/com/digitalpetri/opcua/uanodeset/namespace/NodeSetNodeLoaderReferenceTest.java
@@ -1,0 +1,193 @@
+package com.digitalpetri.opcua.uanodeset.namespace;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.server.AddressSpace;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.eclipse.milo.opcua.stack.core.types.structured.ViewDescription;
+import org.eclipse.milo.opcua.stack.transport.server.OpcServerTransportFactory;
+import org.junit.jupiter.api.Test;
+
+class NodeSetNodeLoaderReferenceTest {
+
+  private static final String TEST_NAMESPACE_URI = "urn:uanodeset:test:reference-normalization";
+
+  @Test
+  void reciprocalDeclarationsLoadExactlyOneReferenceInEachDirection() {
+    LoadedAddressSpace loaded = loadAddressSpace();
+    try {
+      NodeId parentNodeId = loaded.nodeId(5000);
+      NodeId childNodeId = loaded.nodeId(5040);
+
+      assertEquals(
+          1,
+          matchingReferences(
+                  loaded.addressSpace(),
+                  parentNodeId,
+                  NodeIds.HasComponent,
+                  childNodeId,
+                  Reference::isForward)
+              .size());
+      assertEquals(
+          1,
+          matchingReferences(
+                  loaded.addressSpace(),
+                  childNodeId,
+                  NodeIds.HasComponent,
+                  parentNodeId,
+                  Reference::isInverse)
+              .size());
+    } finally {
+      loaded.addressSpace().shutdown();
+    }
+  }
+
+  @Test
+  void oneSidedDeclarationSynthesizesExactlyOneReferenceInEachDirection() {
+    LoadedAddressSpace loaded = loadAddressSpace();
+    try {
+      NodeId parentNodeId = loaded.nodeId(5000);
+      NodeId childNodeId = loaded.nodeId(5041);
+
+      assertEquals(
+          1,
+          matchingReferences(
+                  loaded.addressSpace(),
+                  parentNodeId,
+                  NodeIds.HasProperty,
+                  childNodeId,
+                  Reference::isForward)
+              .size());
+      assertEquals(
+          1,
+          matchingReferences(
+                  loaded.addressSpace(),
+                  childNodeId,
+                  NodeIds.HasProperty,
+                  parentNodeId,
+                  Reference::isInverse)
+              .size());
+    } finally {
+      loaded.addressSpace().shutdown();
+    }
+  }
+
+  @Test
+  void addressSpaceBrowseDoesNotExposeDuplicateIdenticalReferences() {
+    LoadedAddressSpace loaded = loadAddressSpace();
+    try {
+      NodeId parentNodeId = loaded.nodeId(5000);
+      NodeId childNodeId = loaded.nodeId(5040);
+      ViewDescription view = new ViewDescription(NodeId.NULL_VALUE, DateTime.NULL_VALUE, uint(0));
+
+      List<AddressSpace.ReferenceResult> results =
+          loaded
+              .addressSpace()
+              .browse(
+                  new AddressSpace.BrowseContext(loaded.server(), null),
+                  view,
+                  List.of(parentNodeId));
+      AddressSpace.ReferenceResult.ReferenceList result =
+          assertInstanceOf(AddressSpace.ReferenceResult.ReferenceList.class, results.get(0));
+
+      assertEquals(
+          1,
+          result.references().stream()
+              .filter(Reference::isForward)
+              .filter(reference -> NodeIds.HasComponent.equals(reference.getReferenceTypeId()))
+              .filter(
+                  reference ->
+                      reference
+                          .getTargetNodeId()
+                          .toNodeId(loaded.server().getNamespaceTable())
+                          .filter(childNodeId::equals)
+                          .isPresent())
+              .count());
+    } finally {
+      loaded.addressSpace().shutdown();
+    }
+  }
+
+  private static List<Reference> matchingReferences(
+      TestAddressSpace addressSpace,
+      NodeId sourceNodeId,
+      NodeId referenceTypeId,
+      NodeId targetNodeId,
+      Predicate<Reference> directionFilter) {
+
+    return addressSpace.getNodeManager().getReferences(sourceNodeId).stream()
+        .filter(directionFilter)
+        .filter(reference -> referenceTypeId.equals(reference.getReferenceTypeId()))
+        .filter(
+            reference ->
+                reference
+                    .getTargetNodeId()
+                    .toNodeId(addressSpace.server().getNamespaceTable())
+                    .filter(targetNodeId::equals)
+                    .isPresent())
+        .toList();
+  }
+
+  private static LoadedAddressSpace loadAddressSpace() {
+    OpcUaServer server = newBareServer();
+    TestAddressSpace addressSpace = new TestAddressSpace(server);
+    addressSpace.startup();
+
+    UShort namespaceIndex = server.getNamespaceTable().getIndex(TEST_NAMESPACE_URI);
+    return new LoadedAddressSpace(server, addressSpace, namespaceIndex);
+  }
+
+  private static OpcUaServer newBareServer() {
+    OpcUaServerConfig config = OpcUaServerConfig.builder().build();
+    OpcServerTransportFactory transportFactory = profile -> null;
+    return new OpcUaServer(config, transportFactory);
+  }
+
+  private record LoadedAddressSpace(
+      OpcUaServer server, TestAddressSpace addressSpace, UShort namespaceIndex) {
+
+    private NodeId nodeId(int identifier) {
+      return new NodeId(namespaceIndex, identifier);
+    }
+  }
+
+  private static final class TestAddressSpace extends NodeSetNamespace {
+
+    private final List<InputStream> inputStreams;
+
+    private TestAddressSpace(OpcUaServer server) {
+      super(server, TEST_NAMESPACE_URI);
+      inputStreams =
+          List.of(
+              Objects.requireNonNull(
+                  getClass().getResourceAsStream("/ReferenceNormalization.NodeSet2.xml")));
+    }
+
+    @Override
+    protected EncodingContext getEncodingContext() {
+      return server().getStaticEncodingContext();
+    }
+
+    @Override
+    protected List<InputStream> getNodeSetInputStreams() {
+      return inputStreams;
+    }
+
+    private OpcUaServer server() {
+      return getServer();
+    }
+  }
+}

--- a/uanodeset-namespace/src/test/resources/ReferenceNormalization.NodeSet2.xml
+++ b/uanodeset-namespace/src/test/resources/ReferenceNormalization.NodeSet2.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamespaceUris>
+    <Uri>urn:uanodeset:test:reference-normalization</Uri>
+  </NamespaceUris>
+  <Models>
+    <Model ModelUri="urn:uanodeset:test:reference-normalization" Version="1.0.0"
+      PublicationDate="2026-07-18T00:00:00Z">
+      <RequiredModel ModelUri="http://opcfoundation.org/UA/" Version="1.05.04"
+        PublicationDate="2024-12-01T00:00:00Z"/>
+    </Model>
+  </Models>
+  <Aliases>
+    <Alias Alias="HasComponent">i=47</Alias>
+    <Alias Alias="HasProperty">i=46</Alias>
+  </Aliases>
+  <UAObject NodeId="ns=1;i=5000" BrowseName="1:Parent">
+    <DisplayName>Parent</DisplayName>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=5040</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=5041</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=5040" BrowseName="1:ReciprocalChild">
+    <DisplayName>ReciprocalChild</DisplayName>
+    <References>
+      <Reference IsForward="false" ReferenceType="HasComponent">ns=1;i=5000</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=5041" BrowseName="1:OneSidedChild">
+    <DisplayName>OneSidedChild</DisplayName>
+    <References/>
+  </UAObject>
+</UANodeSet>


### PR DESCRIPTION
## Summary

- normalize reciprocal NodeSet reference declarations into a canonical logical relationship
- submit each relationship to Milo once while retaining inverse-reference synthesis for one-sided declarations
- add regression coverage for reciprocal, one-sided, and Browse-visible references

## Root cause

Valid NodeSets may describe a relationship at both endpoints. `NodeSetNodeLoader` previously submitted every XML declaration to Milo, while Milo's `addReferences()` also adds the inverse. Because Milo stores references in a multiset—and absolute and relative target representations are not necessarily equal—the reciprocal declaration produced duplicate Browse results.

## Compatibility

Duplicate XML declarations now have set semantics. The first declaration determines the stored representation, and both browsing directions remain available. NodeSets declaring only one endpoint continue to receive a synthesized inverse reference.

## Validation

- `mise exec -- mvn -q spotless:apply`
- focused `NodeSetNodeLoaderReferenceTest` (3 tests passed)
- `mise exec -- mvn -q clean verify`
- `mise exec -- mvn -q install`
