### PR TITLE
Release version 0.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.digitalpetri.opcua</groupId>
   <artifactId>uanodeset</artifactId>
-  <version>0.5.2-SNAPSHOT</version>
+  <version>0.5.2</version>
   <packaging>pom</packaging>
 
   <name>UANodeSet</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.digitalpetri.opcua</groupId>
   <artifactId>uanodeset</artifactId>
-  <version>0.5.2</version>
+  <version>0.5.3-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>UANodeSet</name>

--- a/uanodeset-core/pom.xml
+++ b/uanodeset-core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.digitalpetri.opcua</groupId>
     <artifactId>uanodeset</artifactId>
-    <version>0.5.2-SNAPSHOT</version>
+    <version>0.5.2</version>
   </parent>
 
   <name>UANodeSet :: Core</name>

--- a/uanodeset-core/pom.xml
+++ b/uanodeset-core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.digitalpetri.opcua</groupId>
     <artifactId>uanodeset</artifactId>
-    <version>0.5.2</version>
+    <version>0.5.3-SNAPSHOT</version>
   </parent>
 
   <name>UANodeSet :: Core</name>

--- a/uanodeset-namespace/pom.xml
+++ b/uanodeset-namespace/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.digitalpetri.opcua</groupId>
     <artifactId>uanodeset</artifactId>
-    <version>0.5.2</version>
+    <version>0.5.3-SNAPSHOT</version>
   </parent>
 
   <name>UANodeSet :: Namespace</name>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.digitalpetri.opcua</groupId>
       <artifactId>uanodeset-core</artifactId>
-      <version>0.5.2</version>
+      <version>0.5.3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.milo</groupId>

--- a/uanodeset-namespace/pom.xml
+++ b/uanodeset-namespace/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.digitalpetri.opcua</groupId>
     <artifactId>uanodeset</artifactId>
-    <version>0.5.2-SNAPSHOT</version>
+    <version>0.5.2</version>
   </parent>
 
   <name>UANodeSet :: Namespace</name>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.digitalpetri.opcua</groupId>
       <artifactId>uanodeset-core</artifactId>
-      <version>0.5.2-SNAPSHOT</version>
+      <version>0.5.2</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.milo</groupId>


### PR DESCRIPTION
## Summary

- merge the 0.5.2 release line back into `main`.
- advance the Maven reactor to `0.5.3-SNAPSHOT`.
- include the type-hierarchy support, post-load node behavior callbacks, and build/CI updates released in [v0.5.2](https://github.com/digitalpetri/uanodeset/releases/tag/v0.5.2).

## Verification

- `mise exec -- mvn -q clean verify`
- 83 tests, 0 failures, 0 errors, 0 skipped; Spotless passed.